### PR TITLE
Fixed scrolling-to-top on first change after creating an Ace Editor

### DIFF
--- a/aceeditor/src/main/java/org/vaadin/aceeditor/client/AceEditorConnector.java
+++ b/aceeditor/src/main/java/org/vaadin/aceeditor/client/AceEditorConnector.java
@@ -108,7 +108,7 @@ public class AceEditorConnector extends AbstractHasComponentsConnector
 	// these things after that.
 	// That's why this complication.
 	// TODO: this may not be the cleanest way to do it...
-	protected int scrollToRowAfterApplyingDiff;
+	protected int scrollToRowAfterApplyingDiff = -1;
 	protected AceRange selectionAfterApplyingDiff;
 
 	public AceEditorConnector() {


### PR DESCRIPTION
To reproduce this bug:
1. Start a new Ace Editor and sets its value to be some text longer than the screen.
2. In your web browser, scroll down in the Ace Editor and then make an edit.
3. The editor will scroll to line 0, likely hiding the edit you've just made.
4. Subsequent edits behave correctly.
