### PR TITLE
Fix focus and blur functionality

### DIFF
--- a/aceeditor/src/main/java/org/vaadin/aceeditor/client/AceEditorConnector.java
+++ b/aceeditor/src/main/java/org/vaadin/aceeditor/client/AceEditorConnector.java
@@ -225,9 +225,8 @@ public class AceEditorConnector extends AbstractHasComponentsConnector
 	
 	@Override
 	public void focusChanged(boolean focused) {
-		if (!focused) {
-			sendToServerImmediately(); // ???
-		}
+	        // send to server even if there's no diff
+			sendToServer(true, true);
 	}
 	
 	public void setTextChangeEventMode(String mode) {


### PR DESCRIPTION
sendToServerImmediately was only called on a blur event. Also, it only sent the event to the server when the text changed. Calling sendToServer(true,true) immediately sends, no matter if the text changed or not.

This way, focus and blur listeners work as they should.
